### PR TITLE
Add LANGUAGE_CODE to html lang attribute in base.html

### DIFF
--- a/hidp_wagtail/templates/hidp/base.html
+++ b/hidp_wagtail/templates/hidp/base.html
@@ -1,5 +1,5 @@
-{% load csp_nonce static %}
-
+{% load csp_nonce i18n static %}
+{% get_current_language as LANGUAGE_CODE %}
 <!doctype html>
 <html lang="{{ LANGUAGE_CODE }}">
 <head>


### PR DESCRIPTION
`LANGUAGE_CODE` will default to `en-us` when not specified, which is probably also an issue (depending on the site being worked in) but one that can be solved later.

This PR depends on the context_processor `django.template.context_processors.i18n` being present in the django settings.py, which is the case since https://github.com/leukeleu/docker-compose-setup/pull/348. `USE_I18N` should also be set to `True`.