### PR TITLE
[HIDP-255] Add middleware to verify Wagtail admin users

### DIFF
--- a/packages/hidp_wagtail/hidp_wagtail/middleware.py
+++ b/packages/hidp_wagtail/hidp_wagtail/middleware.py
@@ -1,0 +1,28 @@
+from hidp.otp.middleware import OTPMiddlewareBase
+
+from django.urls import reverse
+
+
+class OTPRequiredForWagtailAdminMiddleware(OTPMiddlewareBase):
+    """
+    Middleware that requires OTP verification for users accessing the Wagtail admin.
+
+    - Applies only to requests to the Wagtail admin interface.
+    - Redirects to OTP verification or setup if not verified.
+    - Ensures user has Wagtail admin access (wagtailadmin.access_admin).
+    """
+
+    def user_needs_verification(self, user):
+        """
+        Require OTP verification only for users with Wagtail admin access.
+        """
+        return user.has_perm("wagtailadmin.access_admin")
+
+    def request_needs_verification(self, request, view_func):
+        """
+        Apply OTP checks only when accessing the Wagtail admin interface.
+        """
+        if request.path.startswith(reverse("wagtailadmin_home")):
+            return super().request_needs_verification(request, view_func)
+
+        return False

--- a/project/hidp_wagtail_sandbox/settings.py
+++ b/project/hidp_wagtail_sandbox/settings.py
@@ -117,7 +117,7 @@ MIDDLEWARE = [
     # Hello, ID Please
     "hidp.rate_limit.middleware.RateLimitMiddleware",
     "django_otp.middleware.OTPMiddleware",
-    "hidp.otp.middleware.OTPRequiredMiddleware",
+    "hidp_wagtail.middleware.OTPRequiredForWagtailAdminMiddleware",
 ]
 
 ROOT_URLCONF = "hidp_wagtail_sandbox.urls"


### PR DESCRIPTION
This PR adds a middleware, that we can use in Wagtail sites to apply OTP checks only to users that want to access the Wagtail admin.

See https://linear.app/leukeleu/issue/HIDP-255/verify-wagtail-admin-users