### PR TITLE
Style new "logout" button that was added in django-hidp 1.6.0

### DIFF
--- a/packages/hidp_wagtail/hidp_wagtail/static/css/wagtail_hidp.css
+++ b/packages/hidp_wagtail/hidp_wagtail/static/css/wagtail_hidp.css
@@ -33,7 +33,8 @@ h2 {
   font-size: 1.25rem;
 }
 
-button {
+button,
+form[action="/logout/"] button.primary {
   -webkit-font-smoothing: auto;
   -moz-appearance: none;
   background-color: hsl(180.5 100% 24.7%);
@@ -57,9 +58,11 @@ button {
   width: auto;
 }
 
-button:hover {
+button:hover,
+form[action="/logout/"] button.primary:hover {
   background-color: hsl(181.9 100% 18.4%);
   border-color: #0000;
+  color: #fff;
 }
 
 button:disabled {
@@ -108,6 +111,23 @@ form input[type="text"]:focus,
 form input[type="password"]:focus {
   border-color: #3fb9ad;
   outline: none;
+}
+
+form[action="/logout/"] button {
+  background-color: white;
+  color: hsl(180.5 100% 24.7%);
+  cursor: pointer;
+  height: auto;
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+  font-weight: normal;
+  text-underline-offset: 3px;
+}
+
+form[action="/logout/"] button:hover {
+  border-color: #000;
+  color: #000;
 }
 
 /*

--- a/packages/hidp_wagtail/hidp_wagtail/static/css/wagtail_hidp.css
+++ b/packages/hidp_wagtail/hidp_wagtail/static/css/wagtail_hidp.css
@@ -34,7 +34,7 @@ h2 {
 }
 
 button,
-form[action="/logout/"] button.primary {
+form[action$="/logout/"] button.primary {
   -webkit-font-smoothing: auto;
   -moz-appearance: none;
   background-color: hsl(180.5 100% 24.7%);
@@ -59,7 +59,7 @@ form[action="/logout/"] button.primary {
 }
 
 button:hover,
-form[action="/logout/"] button.primary:hover {
+form[action$="/logout/"] button.primary:hover {
   background-color: hsl(181.9 100% 18.4%);
   border-color: #0000;
   color: #fff;
@@ -113,7 +113,7 @@ form input[type="password"]:focus {
   outline: none;
 }
 
-form[action="/logout/"] button {
+form[action$="/logout/"] button {
   background-color: white;
   color: hsl(180.5 100% 24.7%);
   cursor: pointer;
@@ -125,7 +125,7 @@ form[action="/logout/"] button {
   text-underline-offset: 3px;
 }
 
-form[action="/logout/"] button:hover {
+form[action$="/logout/"] button:hover {
   border-color: #000;
   color: #000;
 }

--- a/packages/hidp_wagtail/hidp_wagtail/static/css/wagtail_hidp.css
+++ b/packages/hidp_wagtail/hidp_wagtail/static/css/wagtail_hidp.css
@@ -34,7 +34,7 @@ h2 {
 }
 
 button,
-form[action$="/logout/"] button.primary {
+.logout_form button.primary {
   -webkit-font-smoothing: auto;
   -moz-appearance: none;
   background-color: hsl(180.5 100% 24.7%);
@@ -59,7 +59,7 @@ form[action$="/logout/"] button.primary {
 }
 
 button:hover,
-form[action$="/logout/"] button.primary:hover {
+.logout_form button.primary:hover {
   background-color: hsl(181.9 100% 18.4%);
   border-color: #0000;
   color: #fff;
@@ -113,7 +113,7 @@ form input[type="password"]:focus {
   outline: none;
 }
 
-form[action$="/logout/"] button {
+.logout_form button {
   background-color: white;
   color: hsl(180.5 100% 24.7%);
   cursor: pointer;
@@ -125,7 +125,7 @@ form[action$="/logout/"] button {
   text-underline-offset: 3px;
 }
 
-form[action$="/logout/"] button:hover {
+.logout_form button:hover {
   border-color: #000;
   color: #000;
 }

--- a/packages/hidp_wagtail/hidp_wagtail/static/css/wagtail_hidp_post_login.css
+++ b/packages/hidp_wagtail/hidp_wagtail/static/css/wagtail_hidp_post_login.css
@@ -61,3 +61,9 @@ nav ul li a:hover {
 form {
   max-width: 840px;
 }
+
+.form-group {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}

--- a/packages/hidp_wagtail/hidp_wagtail/templates/hidp/accounts/management/manage_account.html
+++ b/packages/hidp_wagtail/hidp_wagtail/templates/hidp/accounts/management/manage_account.html
@@ -1,0 +1,27 @@
+{% extends 'hidp/base_post_login.html' %}
+{% load i18n %}
+
+{% block title %}{% translate 'Manage account' %}{% endblock %}
+
+{% block main %}
+  <h1>{% translate 'Manage your account information' %}</h1>
+
+  <p>
+    {% blocktranslate trimmed %}
+      You are currently logged in as {{ user }}.
+    {% endblocktranslate %}
+  </p>
+
+  <form action="{{ logout_url }}" method="post">
+    {% csrf_token %}
+    <button type="submit" class="primary">{% translate 'Sign out' %}</button>
+  </form>
+
+  <hr>
+
+  <ul>
+    {% for item in account_management_links %}
+      <li><a href="{{ item.url }}">{{ item.text }}</a></li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/packages/hidp_wagtail/hidp_wagtail/templates/hidp/includes/forms/logout_form.html
+++ b/packages/hidp_wagtail/hidp_wagtail/templates/hidp/includes/forms/logout_form.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+{% comment %}
+The logout_url is required for the form action. It is passed in from the view
+that renders this template. If the logout_url is not provided, the form will not
+be rendered.
+{% endcomment %}
+{% if logout_url %}
+  <form action="{{ logout_url }}" method="post" class="logout_form">
+    {% csrf_token %}
+    <button type="submit">
+      {{ logout_label|default:_("Cancel and return to login") }}
+    </button>
+  </form>
+{% endif %}

--- a/packages/hidp_wagtail/hidp_wagtail/templates/hidp/otp/setup_device.html
+++ b/packages/hidp_wagtail/hidp_wagtail/templates/hidp/otp/setup_device.html
@@ -1,0 +1,78 @@
+{% extends 'hidp/base_post_login.html' %}
+{% load i18n %}
+
+{% block title %}{% translate 'Two-factor Authentication' %}{% endblock %}
+
+{% block main %}
+  <style>
+    .qr-code-container {
+      padding: 1rem;
+      background-color: white;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    .qr-code-image {
+      max-width: 100%;
+      height: auto;
+      width: 200px;
+      aspect-ratio: 1/1;
+    }
+
+    .otp-config-url {
+      white-space: pre-line;
+      word-break: break-all;
+    }
+  </style>
+
+  <h1>{% translate 'Set up two-factor authentication' %}</h1>
+
+  <form method="post">
+    {% csrf_token %}
+
+    <h2>{% translate 'Scan the QR code' %}</h2>
+    <div class="qr-code-container">
+      <img
+        class="qr-code-image"
+        src="{{ qrcode|safe }}"
+        alt="{% translate 'QR code for setting up two-factor authentication. Scan with your authenticator app.' %}"
+      />
+    </div>
+
+    <details>
+      <summary>
+        {% translate 'Having trouble scanning the QR code?' %}
+      </summary>
+      <p>
+        {% translate 'Enter the following URL in your authenticator app:' %}
+        <pre class="otp-config-url">{{ config_url}}</pre>
+      </p>
+    </details>
+
+    {{ form.non_field_errors }}
+
+    <p>
+      {{ form.otp_token.errors }}
+      {{ form.otp_token.label_tag }}
+      {{ form.otp_token }}
+    </p>
+
+    <h2>{% translate 'Recovery codes' %}</h2>
+    <pre>{{ recovery_codes }}</pre>
+
+    <p>
+      {{ form.confirm_stored_backup_tokens.errors }}
+      {{ form.confirm_stored_backup_tokens.label_tag }}
+      {{ form.confirm_stored_backup_tokens }}
+    </p>
+
+    <div class="form-group">
+      {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Submit') %}
+      <a href="{{ back_url }}">{% translate 'Back' %}</a>
+    </div>
+  </form>
+
+  {% include 'hidp/includes/forms/logout_form.html' %}
+
+</div>
+{% endblock %}

--- a/packages/hidp_wagtail/pyproject.toml
+++ b/packages/hidp_wagtail/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Wouter de Vries", email = "wdevries@leukeleu.nl" },
 ]
 dependencies = [
-    "django-hidp>=1.5.0,<2",
+    "django-hidp>=1.6.0,<2",
 ]
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -2,7 +2,7 @@ Django~=4.2.0
 django-email-bandit~=2.0.0
 leukeleu-django-checks~=1.2
 leukeleu-django-gdpr~=1.4
-django-hidp[recommended]~=1.5.0
+django-hidp[recommended]~=1.6.0
 psycopg2-binary~=2.9.6
 wagtail~=6.3.3
 -e ../packages/hidp_wagtail  # Install editable


### PR DESCRIPTION
After this PR:

- The required version of djang-hidp is updated to 1.6.0 to get the "logout"-button
- Styling has been updated to account for the new button

See screenshots below:

<img width="452" height="453" alt="Screenshot 2025-07-25 at 11 34 01" src="https://github.com/user-attachments/assets/8a0a30e1-f905-4f56-a795-d96188943b13" />
<img width="491" height="581" alt="Screenshot 2025-07-25 at 11 33 53" src="https://github.com/user-attachments/assets/17bdc769-9062-467e-823c-244b681e6487" />
<img width="597" height="307" alt="Screenshot 2025-07-25 at 11 33 03" src="https://github.com/user-attachments/assets/19ccd1a9-e837-4d7e-9bb7-a6c97186c9bc" />
