### PR TITLE
LKL-2375 Use setup-uv

### DIFF
--- a/.github/actions/python-qa/action.yml
+++ b/.github/actions/python-qa/action.yml
@@ -11,28 +11,19 @@ runs:
     - name: Checkout code
       uses: actions/checkout@v5
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
 
-    - name: Install uv
-      run: |
-        python -m pip install --root-user-action=ignore -U uv
-      working-directory: ${{ inputs.working-directory }}
-      shell: bash
-
     - name: Install dependencies
       run: |
-        uv venv ./var/venv
-        source ./var/venv/bin/activate
         make install-pipeline
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 
     - name: Test
       run: |
-        source ./var/venv/bin/activate
         make test
       working-directory: ${{ inputs.working-directory }}
       shell: bash


### PR DESCRIPTION
setup-uv is being used in Github Actions instead of setup-python. Uv takes care of python installation and eliminates the need to activate venv in each step